### PR TITLE
Feat: 이미지 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/searchapi/controller/SearchImageController.java
+++ b/src/main/java/com/example/searchapi/controller/SearchImageController.java
@@ -1,0 +1,26 @@
+package com.example.searchapi.controller;
+
+import com.example.searchapi.dto.SearchImageDTO;
+import com.example.searchapi.service.SearchImageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class SearchImageController {
+
+    private final SearchImageService searchImageService;
+
+    @GetMapping("/tag")
+    public ResponseEntity<SearchImageDTO.Response> searchByTags(@RequestAttribute BigDecimal userId,
+                                                                @ModelAttribute SearchImageDTO.Request request) {
+
+        return ResponseEntity.ok(searchImageService.searchByTags(request.toCommand(userId)));
+    }
+}

--- a/src/main/java/com/example/searchapi/dto/SearchImageDTO.java
+++ b/src/main/java/com/example/searchapi/dto/SearchImageDTO.java
@@ -1,0 +1,37 @@
+package com.example.searchapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class SearchImageDTO {
+
+    @Builder
+    public record Request(List<String> tags, Integer size, Long nextImageId) {
+
+        public Command toCommand(BigDecimal userId) {
+            return Command.builder()
+                    .userId(userId)
+                    .tags(tags)
+                    .size(size)
+                    .nextImageId(nextImageId)
+                    .build();
+        }
+    }
+
+    @Builder
+    public record Command(BigDecimal userId, List<String> tags, Integer size, Long nextImageId) {
+
+    }
+
+
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Response(List<Long> imageIds, Boolean hasNext, Long nextImageId) {
+
+    }
+
+
+}

--- a/src/main/java/com/example/searchapi/entity/Image.java
+++ b/src/main/java/com/example/searchapi/entity/Image.java
@@ -1,0 +1,29 @@
+package com.example.searchapi.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+@Getter
+@Entity
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ImageID")
+    private Long imageID;
+
+    @Column(name = "UserID")
+    private BigDecimal userID;
+
+    @Column(name = "S3URL")
+    private String s3Url;
+
+    @CreationTimestamp
+    @Column(name = "UploadTime")
+    private Timestamp uploadTime;
+
+}

--- a/src/main/java/com/example/searchapi/entity/ImageHasTags.java
+++ b/src/main/java/com/example/searchapi/entity/ImageHasTags.java
@@ -12,7 +12,7 @@ public class ImageHasTags {
 
     public record PK(Long TagID, Long ImageID) implements Serializable {
 
-    };
+    }
 
     @EmbeddedId
     private PK pk;

--- a/src/main/java/com/example/searchapi/entity/ImageHasTags.java
+++ b/src/main/java/com/example/searchapi/entity/ImageHasTags.java
@@ -1,0 +1,20 @@
+package com.example.searchapi.entity;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+@Entity(name = "ImageTag")
+public class ImageHasTags {
+
+    public record PK(Long TagID, Long ImageID) implements Serializable {
+
+    };
+
+    @EmbeddedId
+    private PK pk;
+
+}

--- a/src/main/java/com/example/searchapi/entity/Tag.java
+++ b/src/main/java/com/example/searchapi/entity/Tag.java
@@ -1,0 +1,18 @@
+package com.example.searchapi.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "TagID")
+    private Long tagID;
+
+    @Column(name = "TagName")
+    private String tagName;
+
+}

--- a/src/main/java/com/example/searchapi/repository/ImageRepository.java
+++ b/src/main/java/com/example/searchapi/repository/ImageRepository.java
@@ -1,0 +1,15 @@
+package com.example.searchapi.repository;
+
+import com.example.searchapi.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    List<Image> findByUserIDIsAndImageIDLessThanEqual(BigDecimal UserID, Long imageID);
+    List<Image> findAllByUserIDIsAndImageIDIsInOrderByUploadTimeDesc(BigDecimal UserID, List<Long> ImageID);
+    List<Image> findAllByUserIDIsOrderByUploadTimeDesc(BigDecimal UserID);
+
+}

--- a/src/main/java/com/example/searchapi/repository/ImageTagAssociationRepository.java
+++ b/src/main/java/com/example/searchapi/repository/ImageTagAssociationRepository.java
@@ -1,0 +1,14 @@
+package com.example.searchapi.repository;
+
+import com.example.searchapi.entity.ImageHasTags;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ImageTagAssociationRepository extends JpaRepository<ImageHasTags, ImageHasTags.PK> {
+
+    @Query("SELECT it.pk.ImageID FROM ImageTag it WHERE it.pk.TagID IN :tags GROUP BY it.pk.ImageID HAVING COUNT(DISTINCT it.pk.TagID) = :tagCount")
+    List<Long> findAllImageIDsWithAllTagIDs(List<Long> tags, int tagCount);
+
+}

--- a/src/main/java/com/example/searchapi/repository/TagRepository.java
+++ b/src/main/java/com/example/searchapi/repository/TagRepository.java
@@ -1,0 +1,12 @@
+package com.example.searchapi.repository;
+
+import com.example.searchapi.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    List<Tag> findAllByTagNameIsIn(List<String> names);
+
+}

--- a/src/main/java/com/example/searchapi/service/SearchImageService.java
+++ b/src/main/java/com/example/searchapi/service/SearchImageService.java
@@ -1,0 +1,9 @@
+package com.example.searchapi.service;
+
+import com.example.searchapi.dto.SearchImageDTO;
+
+public interface SearchImageService {
+
+    SearchImageDTO.Response searchByTags(SearchImageDTO.Command command);
+
+}

--- a/src/main/java/com/example/searchapi/service/impl/SearchImageServiceImpl.java
+++ b/src/main/java/com/example/searchapi/service/impl/SearchImageServiceImpl.java
@@ -1,0 +1,98 @@
+package com.example.searchapi.service.impl;
+
+import com.example.searchapi.dto.SearchImageDTO;
+import com.example.searchapi.entity.Image;
+import com.example.searchapi.entity.Tag;
+import com.example.searchapi.repository.ImageRepository;
+import com.example.searchapi.repository.ImageTagAssociationRepository;
+import com.example.searchapi.repository.TagRepository;
+import com.example.searchapi.service.SearchImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SearchImageServiceImpl implements SearchImageService {
+
+    private final ImageRepository imageRepository;
+    private final ImageTagAssociationRepository associationRepository;
+    private final TagRepository tagRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public SearchImageDTO.Response searchByTags(SearchImageDTO.Command command) {
+        final Long targetImageId = Optional.ofNullable(command.nextImageId()).orElse(Long.MAX_VALUE);
+        final Timestamp targetTimestamp = imageRepository.findByUserIDIsAndImageIDLessThanEqual(command.userId(), targetImageId)
+                .stream()
+                .map(Image::getUploadTime)
+                .max(Comparator.comparing(Timestamp::getTime))
+                .orElse(Timestamp.valueOf(LocalDateTime.now()));
+        final Integer searchSize = Integer.max(command.size() , 0); //size 버그 방지
+
+        //tag 테이블로부터 키워드를 가진 tagID를 모두 가져옴
+        //엔티티 연관관계 매핑으로 Join 후 쿼리를 한 번만 보내는 것이 좋을까..?
+        List<Long> tagIDs = tagRepository.findAllByTagNameIsIn(command.tags()).stream()
+                .map(Tag::getTagID)
+                .toList();
+
+        //TO-DO: 이미지 목록을 Redis에 캐싱함
+        final List<Image> images;
+        if (tagIDs.isEmpty()) {
+            //태그가 없다면 유저의 모든 이미지를 불러옴
+            images = imageRepository.findAllByUserIDIsOrderByUploadTimeDesc(command.userId());
+        } else {
+            //ImageTag 테이블로부터 tagID를 모두 가진 imageID만 가져옴
+            List<Long> imageIDs = associationRepository.findAllImageIDsWithAllTagIDs(tagIDs, tagIDs.size());
+
+            //Image 테이블로부터 사용자의 이미지이면서 ImageIDs에 포함되고 최신순으로 정렬한 image 목록을 가져옴
+            images = imageRepository.findAllByUserIDIsAndImageIDIsInOrderByUploadTimeDesc(command.userId(), imageIDs);
+        }
+
+        //targetTimestamp보다 작거나 같은 이미지들 중 클라이언트가 보낸 size만큼 잘라서 저장함
+        //TO-DO: 아래 stream 성능 개선, stream으로 조회되는 Image들의 중복이 좀 많음
+        List<Image> resultImages = images.stream()
+                .filter(image -> image.getUploadTime().before(targetTimestamp) || image.getUploadTime().equals(targetTimestamp))
+                .limit(searchSize)
+                .toList();
+
+        //만약 검색된 이미지가 하나도 없다면 빈 리스트를 반환함
+        if (resultImages.isEmpty()) {
+            return SearchImageDTO.Response.builder()
+                    .imageIds(Collections.emptyList())
+                    .hasNext(false)
+                    .build();
+        }
+
+        //선택된 이미지들 중 가장 오래 전에 저장된 uploadTime을 가져옴
+        Timestamp minimumUploadTime = resultImages.stream()
+                .map(Image::getUploadTime)
+                .min(Comparator.comparing(Timestamp::getTime))
+                .get();
+
+        //minimumUploadTime보다 더 오래 전에 저장된 이미지들 중 하나를 골라 ImageID만 가져옴
+        Long nextImageId = images.stream()
+                .filter(image -> image.getUploadTime().before(minimumUploadTime))
+                .limit(1)
+                .map(Image::getImageID)
+                .findFirst()
+                .orElse(null);
+
+        //nextImageId가 null인지 아닌지 저장함
+        Boolean hasNext = nextImageId != null;
+
+        //Response 객체에 모두 담아 반환
+        return SearchImageDTO.Response.builder()
+                .imageIds(resultImages.stream().map(Image::getImageID).toList())
+                .hasNext(hasNext)
+                .nextImageId(nextImageId)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,82 @@
 spring:
   application:
     name: SearchAPI
+  profiles:
+    group:
+      dev: mysql-dev
+      prod: mysql-prod
+      test: h2
+  jpa:
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
 auth:
   server-url: ${AUTH_SERVER_URL}
   api-url: ${AUTH_API_URL}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: h2
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:db
+    username: ${DATABASE_ID}
+    password: ${DATABASE_PW}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+    database-platform: org.hibernate.dialect.H2Dialect
+    database: h2
+
+
+---
+spring:
+  config:
+    activate:
+      on-profile: mysql-dev
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DATABASE_ID}
+    password: ${DATABASE_PW}
+    hikari:
+      data-source-properties:
+        rewriteBatchedStatements: true
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: false
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database: mysql
+
+---
+spring:
+  config:
+    activate:
+      on-profile: mysql-prod
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DATABASE_ID}
+    password: ${DATABASE_PW}
+    hikari:
+      data-source-properties:
+        rewriteBatchedStatements: true
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        show_sql: false
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database: mysql


### PR DESCRIPTION
## 구현 목록
- 클라이언트로부터 tags, size, nextImageId query를 받음 (tags, nextImageId는 optional, size는 0 이상)
- 조회에 사용되는 tags가 없다면 사용자의 모든 이미지들를 가져옴
- tags가 있다면 선택된 tags를 모두 포함하는 이미지들을 가져옴
- 모든 이미지들은 업로드 시간 기준 최신순으로 정렬되어 있음
- 만약 nextImageId가 있다면 해당 이미지부터 가장 오래된 이미지들을 필터링함
- 조회된 이미지들은 size만큼만 ImageID로 변환해 클라이언트에게 전달함
- 만약 추가로 조회 가능한 이미지들이 남아 있다면 조회되지 않은 이미지의 ID를 클라이언트에게 같이 전달함
(다음 조회에 사용할 nextImageID로 사용하기 위해서)