### PR TITLE
hotfix: NotKoreanTagFoundException 을 유발하는 조건에 ! 추가

### DIFF
--- a/src/main/java/com/example/searchapi/trie/Trie.java
+++ b/src/main/java/com/example/searchapi/trie/Trie.java
@@ -96,7 +96,7 @@ public class Trie {
         }
     }
     private void checkNotKoreanTag(String searchText) {
-        if(searchText.matches("[가-힣ㄱ-ㅎ]+")){
+        if(!searchText.matches("[가-힣ㄱ-ㅎ]+")){
             throw new NotKoreanTagFoundException();
         }
     }


### PR DESCRIPTION
## 수정사항
+ ```NotKoreanTagFoundException``` 을 유발하는 조건 ```!searchText.matches("[가-힣ㄱ-ㅎ]+")``` 로 변경 