### PR TITLE
fix: trie 로직 문제 발견후 수정

### DIFF
--- a/src/main/java/com/example/searchapi/trie/Trie.java
+++ b/src/main/java/com/example/searchapi/trie/Trie.java
@@ -31,14 +31,12 @@ public class Trie {
 
         node = node.addChildNode(midSoundIdx);
 
+        node = node.addChildNode(lastSoundIdx);
 
-        if(lastSoundIdx != null){
-            node = node.addChildNode(lastSoundIdx);
-        }
         return node;
     }
 
-    private Node searchNodeFromLetter(Node node, Phoneme phoneme) {
+    private Node searchNodeFromLetter(Node node, Phoneme phoneme, boolean isLastCharacter) {
         Integer firstSoundIdx = phoneme.getFirstSoundIdx();
         Integer midSoundIdx = phoneme.getMidSoundIdx();
         Integer lastSoundIdx = phoneme.getLastSoundIdx();
@@ -49,12 +47,11 @@ public class Trie {
             if(node.findNode(midSoundIdx)){
                 node = node.getNextNode(midSoundIdx);
 
-                if(!lastSoundIdx.equals(Phoneme.LAST_SOUND_NULL_INDEX)){
+                if (!isLastCharacter){
                     if(node.findNode(lastSoundIdx)){
                         node = node.getNextNode(lastSoundIdx);
                         return node;
                     }
-                    return null;
                 }
                 return node;
             }
@@ -64,7 +61,9 @@ public class Trie {
     }
 
     private Node navigateToNode(Node node ,String searchText) {
-        for (int i = 0; i < searchText.length(); i++) {
+        int length = searchText.length();
+
+        for (int i = 0; i < length; i++) {
             char character = searchText.charAt(i);
 
             if(Phoneme.checkOnlyFirstSound(character)){
@@ -72,7 +71,7 @@ public class Trie {
                 node = node.getNextNode(idx);
             }else{
                 Phoneme phoneme = Phoneme.from(character);
-                node = searchNodeFromLetter(node, phoneme);
+                node = searchNodeFromLetter(node, phoneme, (i == length - 1));
             }
             if(node == null) return null;
         }

--- a/src/test/java/com/example/searchapi/trie/TrieTest.java
+++ b/src/test/java/com/example/searchapi/trie/TrieTest.java
@@ -39,6 +39,11 @@ public class TrieTest {
         List<String> list6 = trie.searchTags("ㅍ");
         list6.forEach(System.out::println);
 
+        System.out.println("===================");
+
+        List<String> list7 = trie.searchTags("하ㄴ");
+        list7.forEach(System.out::println);
+
     }
 
     @Test


### PR DESCRIPTION
+ 입력 문자열을 가지고 태그를 찾는 과정에서 문제 발생.
+ 입력된 문자열을 개별 문자로 쪼갠 후 개별 문자가 마지막 글자인지 아닌지에 따라 로직이 달라져야 한다.
+ 예를 들어 입력된 문자열이 '하' 인 경우 종성이 아직 결정되지 않은 상황이지만 '하ㄴ' 의 경우 '하'의 종성은 없는 걸로 결정된 상황이다.