### PR TITLE
Feat: 입력한 문자를 바탕으로 자동완성이 가능한 태그 목록을 반환하는 기능 추가

### DIFF
--- a/src/main/java/com/example/searchapi/controller/SearchImageController.java
+++ b/src/main/java/com/example/searchapi/controller/SearchImageController.java
@@ -1,6 +1,8 @@
 package com.example.searchapi.controller;
 
+import com.example.searchapi.dto.AutoCompleteTagDTO;
 import com.example.searchapi.dto.SearchImageDTO;
+import com.example.searchapi.service.AutoCompleteTagService;
 import com.example.searchapi.service.SearchImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,11 +18,21 @@ import java.math.BigDecimal;
 public class SearchImageController {
 
     private final SearchImageService searchImageService;
+    private final AutoCompleteTagService autoCompleteTagService;
 
     @GetMapping("/tag")
     public ResponseEntity<SearchImageDTO.Response> searchByTags(@RequestAttribute BigDecimal userId,
                                                                 @ModelAttribute SearchImageDTO.Request request) {
 
         return ResponseEntity.ok(searchImageService.searchByTags(request.toCommand(userId)));
+    }
+
+    @GetMapping("/auto-complete")
+    public ResponseEntity<AutoCompleteTagDTO.Response> getAutoCompleteTags(@RequestAttribute BigDecimal userId,
+                                                                           @ModelAttribute AutoCompleteTagDTO.Request request) {
+
+        log.info(request.input());
+
+        return ResponseEntity.ok(autoCompleteTagService.getAutoCompleteTags(request.toCommand(userId)));
     }
 }

--- a/src/main/java/com/example/searchapi/dto/AutoCompleteTagDTO.java
+++ b/src/main/java/com/example/searchapi/dto/AutoCompleteTagDTO.java
@@ -1,0 +1,30 @@
+package com.example.searchapi.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class AutoCompleteTagDTO {
+
+    @Builder
+    public record Request(String input) {
+
+        public Command toCommand(BigDecimal userId) {
+            return Command.builder()
+                    .userId(userId)
+                    .input(input)
+                    .build();
+        }
+    }
+
+    @Builder
+    public record Command(BigDecimal userId, String input) {
+
+    }
+
+    @Builder
+    public record Response(List<String> suggestKeywords) {
+
+    }
+}

--- a/src/main/java/com/example/searchapi/repository/ImageRepository.java
+++ b/src/main/java/com/example/searchapi/repository/ImageRepository.java
@@ -2,6 +2,7 @@ package com.example.searchapi.repository;
 
 import com.example.searchapi.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -11,5 +12,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findByUserIDIsAndImageIDLessThanEqual(BigDecimal UserID, Long imageID);
     List<Image> findAllByUserIDIsAndImageIDIsInOrderByUploadTimeDesc(BigDecimal UserID, List<Long> ImageID);
     List<Image> findAllByUserIDIsOrderByUploadTimeDesc(BigDecimal UserID);
+
+    @Query("SELECT i.imageID FROM Image i WHERE i.userID = :UserID")
+    List<Long> findAllImageIDByUserIDIs(BigDecimal UserID);
 
 }

--- a/src/main/java/com/example/searchapi/repository/ImageTagAssociationRepository.java
+++ b/src/main/java/com/example/searchapi/repository/ImageTagAssociationRepository.java
@@ -5,10 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Set;
 
 public interface ImageTagAssociationRepository extends JpaRepository<ImageHasTags, ImageHasTags.PK> {
 
     @Query("SELECT it.pk.ImageID FROM ImageTag it WHERE it.pk.TagID IN :tags GROUP BY it.pk.ImageID HAVING COUNT(DISTINCT it.pk.TagID) = :tagCount")
     List<Long> findAllImageIDsWithAllTagIDs(List<Long> tags, int tagCount);
+
+    @Query("SELECT it.pk.TagID FROM ImageTag it WHERE it.pk.ImageID IN :images GROUP BY it.pk.TagID")
+    Set<Long> findDistinctTagIDByImageIDIsIn(List<Long> images);
 
 }

--- a/src/main/java/com/example/searchapi/repository/TagRepository.java
+++ b/src/main/java/com/example/searchapi/repository/TagRepository.java
@@ -2,11 +2,16 @@ package com.example.searchapi.repository;
 
 import com.example.searchapi.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     List<Tag> findAllByTagNameIsIn(List<String> names);
+
+    @Query("SELECT t.tagName FROM Tag t WHERE t.tagID IN :tagIDs")
+    List<String> findAllTagNameByTagIDIsIn(Collection<Long> tagIDs);
 
 }

--- a/src/main/java/com/example/searchapi/service/AutoCompleteTagService.java
+++ b/src/main/java/com/example/searchapi/service/AutoCompleteTagService.java
@@ -1,0 +1,9 @@
+package com.example.searchapi.service;
+
+import com.example.searchapi.dto.AutoCompleteTagDTO;
+
+public interface AutoCompleteTagService {
+
+    AutoCompleteTagDTO.Response getAutoCompleteTags(AutoCompleteTagDTO.Command command);
+
+}

--- a/src/main/java/com/example/searchapi/service/impl/AutoCompleteTagServiceImpl.java
+++ b/src/main/java/com/example/searchapi/service/impl/AutoCompleteTagServiceImpl.java
@@ -1,0 +1,64 @@
+package com.example.searchapi.service.impl;
+
+import com.example.searchapi.dto.AutoCompleteTagDTO;
+import com.example.searchapi.entity.Image;
+import com.example.searchapi.entity.Tag;
+import com.example.searchapi.exception.NotKoreanTagFoundException;
+import com.example.searchapi.repository.ImageRepository;
+import com.example.searchapi.repository.ImageTagAssociationRepository;
+import com.example.searchapi.repository.TagRepository;
+import com.example.searchapi.service.AutoCompleteTagService;
+import com.example.searchapi.trie.Trie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class AutoCompleteTagServiceImpl implements AutoCompleteTagService {
+
+    private final ImageRepository imageRepository;
+    private final ImageTagAssociationRepository associationRepository;
+    private final TagRepository tagRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AutoCompleteTagDTO.Response getAutoCompleteTags(AutoCompleteTagDTO.Command command) {
+
+        //사용자의 모든 이미지를 가져옴
+        List<Long> imageIDs = imageRepository.findAllImageIDByUserIDIs(command.userId());
+
+        //이미지가 가진 태그 목록 중 중복을 제거한 태그 ID를 가져옴
+        Set<Long> uniqueTags = associationRepository.findDistinctTagIDByImageIDIsIn(imageIDs);
+
+        //태그 ID에 해당하는 태그 이름을 가져옴
+        List<String> tagNames = tagRepository.findAllTagNameByTagIDIsIn(uniqueTags);
+
+        final List<String> autoCompleteTags;
+        try {
+            //Trie 자료구조 생성
+            Trie trie = new Trie();
+            trie.insertAll(tagNames);
+
+            //Trie를 바탕으로 자동완성이 가능한 tag를 계산함
+            autoCompleteTags = trie.searchTags(command.input());
+
+        } catch (NotKoreanTagFoundException notFoundException) {
+            //검색하고 있는 키워드가 빈 문자열일 때도 catch에 걸림
+            //빈 문자열인 경우 모든 태그가 자동완성 대상이 되지만
+            //클라이언트에게 보낼 데이터의 개수가 너무 많기 때문에
+            //빈 문자열은 자동완성 태그를 하나도 보내지 않음
+            return AutoCompleteTagDTO.Response.builder()
+                    .suggestKeywords(Collections.emptyList())
+                    .build();
+        }
+
+        return AutoCompleteTagDTO.Response.builder()
+                .suggestKeywords(autoCompleteTags)
+                .build();
+    }
+}

--- a/src/main/java/com/example/searchapi/service/impl/AutoCompleteTagServiceImpl.java
+++ b/src/main/java/com/example/searchapi/service/impl/AutoCompleteTagServiceImpl.java
@@ -1,8 +1,6 @@
 package com.example.searchapi.service.impl;
 
 import com.example.searchapi.dto.AutoCompleteTagDTO;
-import com.example.searchapi.entity.Image;
-import com.example.searchapi.entity.Tag;
 import com.example.searchapi.exception.NotKoreanTagFoundException;
 import com.example.searchapi.repository.ImageRepository;
 import com.example.searchapi.repository.ImageTagAssociationRepository;


### PR DESCRIPTION
- 사용자가 저장한 이미지들이 가지는 태그 목록 중 클라이언트가 보낸 문자를 접두사로 하는 태그 목록을 반환함
- 클라이언트로부터 받는 문자는 한글만 허용함
- 한글이 아닌 다른 문자가 섞여있을 경우 빈 태그 목록을 반환함
- 만약 빈 문자를 받은 경우에는 가능한 태그가 너무 많기 때문에 빈 태그 목록을 반환함
- 쿼리는 필요한 정보만 가져올 수 있도록 구성함