### PR TITLE
fix: 웹 브라우저에서 한글 파라미터가 적용되지 않던 버그 해결

### DIFF
--- a/src/main/java/com/example/searchapi/configuration/TomcatWebCustomConfig.java
+++ b/src/main/java/com/example/searchapi/configuration/TomcatWebCustomConfig.java
@@ -1,0 +1,14 @@
+package com.example.searchapi.configuration;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatWebCustomConfig implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.addConnectorCustomizers(connector -> connector.setProperty("relaxedQueryChars", "<>[\\]^`{|}"));
+    }
+}


### PR DESCRIPTION
### 변경점
웹 브라우저에서 한글 파라미터를 담은 URL로 GET 요청할 때 허용되지 않는 문자가 담겨 톰켓 서버에서 차단하는 버그를 수정함