### PR TITLE
fix: 파라미터에서 사용한 tags라는 이름이 adblock에 차단되어 get 요청을 못 보내는 버그 수정

### DIFF
--- a/src/main/java/com/example/searchapi/dto/SearchImageDTO.java
+++ b/src/main/java/com/example/searchapi/dto/SearchImageDTO.java
@@ -9,12 +9,12 @@ import java.util.List;
 public class SearchImageDTO {
 
     @Builder
-    public record Request(List<String> tags, Integer size, Long nextImageId) {
+    public record Request(List<String> keywords, Integer size, Long nextImageId) {
 
         public Command toCommand(BigDecimal userId) {
             return Command.builder()
                     .userId(userId)
-                    .tags(tags)
+                    .tags(keywords)
                     .size(size)
                     .nextImageId(nextImageId)
                     .build();


### PR DESCRIPTION
### 변경점
URL 파라미터에서 사용한 tags 라는 이름이 adblock과 같은 광고 차단 프로그램의 키워드에 걸려 GET 요청을 보내지 못 해 tags --> keywords 로 변경함